### PR TITLE
Add kernel revision reference

### DIFF
--- a/lineage-17.1.xml
+++ b/lineage-17.1.xml
@@ -12,7 +12,7 @@
   <project path="hardware/samsung" name="LineageOS/android_hardware_samsung" />
 
  <!-- Common Samsung MSM8916 Kernel -->
-  <project path="kernel/samsung/msm8916" name="samsung-msm8916-dev/android_kernel_samsung_msm8916" remote="samsung-msm8916-dev"/>
+  <project path="kernel/samsung/msm8916" name="samsung-msm8916-dev/android_kernel_samsung_msm8916" remote="samsung-msm8916-dev" revision="android-10.0"/>
 
  <!-- Vendor Trees (for all devices) -->
   <project path="vendor/samsung" name="samsung-msm8916-dev/android_vendor_samsung" groups="device" remote="samsung-msm8916-dev"/>


### PR DESCRIPTION
Adds the necessary kernel repo branch, otherwise when repo syncing, it will search for the non-existent lineage-17.1 branch and fail to sync.